### PR TITLE
Small update to README, add "prompt" services

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.8)
+project(ai_msgs)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+find_package(sensor_msgs REQUIRED)
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+  "srv/Prompt.srv"
+  "srv/PromptWithImage.srv"
+  DEPENDENCIES
+  sensor_msgs
+)
+
+ament_export_dependencies(rosidl_default_runtime)
+ament_package()

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # ai_msgs
+
+Messages for prompting or otherwise interacting with AI models.

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>ai_msgs</name>
+  <version>0.0.0</version>
+  <description>Messages for interaction with AI models</description>
+  <maintainer email="andyz@utexas.edu">andy</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
+
+  <depend>sensor_msgs</depend>
+
+  <exec_depend>rosidl_default_runtime</exec_depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/srv/Prompt.srv
+++ b/srv/Prompt.srv
@@ -1,0 +1,3 @@
+string prompt
+---
+bool response

--- a/srv/PromptWithImage.srv
+++ b/srv/PromptWithImage.srv
@@ -1,0 +1,4 @@
+string prompt
+sensor_msgs/Image image
+---
+bool response


### PR DESCRIPTION
The background for why this is necessary is here:  https://github.com/ros-navigation/navigation2/issues/4484

Basically, there's a good navigation use case for prompting an AI model but the actual prompting of the model is generic enough that it probably doesn't belong in the nav2 repo.

These initial service types should be sufficient for interacting with LLM's like ChatGPT.